### PR TITLE
Update Exception.h

### DIFF
--- a/src/Exception.h
+++ b/src/Exception.h
@@ -10,11 +10,11 @@ namespace chesspp
     {
         using std::exception::what;
     public:
-        exception() throw() {}
-        virtual ~exception() throw() {};
-        exception(const exception &) throw() {}
+        exception() {}
+        virtual ~exception() {};
+        exception(const exception &) {}
 
-        exception(const std::string &_e) throw() : e(_e) {}
+        exception(const std::string &_e) : e(_e) {}
         virtual const char *what() { return e.c_str(); }
         
     private:


### PR DESCRIPTION
Removed "throw( )" specifiers. Such specifiers are redundant as the compiler cannot guarantee that functions with the "throw( )" specifier will not throw exceptions. If using C++11, use "noexcept".
