### PR TITLE
Add include ordering rule to styleguide

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -15,7 +15,6 @@ Style Guide & Coding Conventions
 - Prefer `lowerCamelCase` for member function names
 - Prefer `lower_case_underscore` for private member names
 - Prefer `lwrabbrcase` for namespace names
-- Prefer to not use "get" or "set" in the names of getters and setters
 - Braces should be on their own lines, even for empty definitions
 - Namespaces cause indentation to occur, inclusion guards do not
 - Avoid using raw pointers when possible


### PR DESCRIPTION
The goal is to reduce header coupling so that each file has to include the header it needs and it can't get them by being included from other files.

For instance, a scenario to avoid:

``` cpp
//Class.cpp
#include <cstdint>
#include "OtherClass.hpp"
//...
```

``` cpp
//OtherClass.hpp
//...
std::uint8_t blah; //works due to include order (bad)
//...
```

~~EDIT: Also, it's pretty ugly and annoying to use "get" and "set" in the names of getter and setters - it should be obvious that they either get or set data, you don't want to type that every time.~~
