### PR TITLE
Link to gh-pages in wiki

### DIFF
--- a/Home.mediawiki
+++ b/Home.mediawiki
@@ -5,3 +5,5 @@ Check out the information on [[Building]] and on the [[Design]] of the project.
 Devolper IRC Channel:<br/>
 irc.freenode.net #ChessPlusPlus
 <br/>(You can join via [http://webchat.freenode.net/ webchat] if you don't have a client)
+
+There is also the [http://cpluspluscom.GitHub.IO/ChessPlusPlus/ website] hosted by GitHub Pages, which is focused on maintaining game content. This wiki is focused on maintaining information on coding for the project.


### PR DESCRIPTION
This is just testing how PRs work for the wiki branch I set up. Until now I had no idea that wikis could be set up as a branch, I just knew they [counted as a git repository](https://github.com/cpluspluscom/ChessPlusPlus/wiki/_access). With the branch, though, we can do things via PRs :)
