### PR TITLE
Move definitions into cpp files

### DIFF
--- a/src/Debug.cpp
+++ b/src/Debug.cpp
@@ -1,0 +1,78 @@
+#include <Debug.hpp>
+
+
+LogUtil::LogUtil_buffer::LogUtil_buffer(std::ostream &sink_, std::size_t buff_sz )
+: sink(sink_)
+, buffer(buff_sz + 1)
+{
+    sink.clear();
+    char *base = &buffer.front();
+    setp(base, base + buffer.size()-1); //reserve an extra char for calls to overflow
+}
+
+//Applies timestamps and flushes buffer
+bool LogUtil::LogUtil_buffer::timestamp_and_flush()
+{
+    std::stringstream out;
+    for(char *p = pbase(), *e = pptr(); p != e; ++p)
+    {
+        if(*p == '\n') timestamp_on_next_text = true;
+        else if(timestamp_on_next_text)
+        {
+            if(!std::isspace(*p)) out << timestamp();
+            timestamp_on_next_text = false;
+        }
+        out << *p;
+    }
+
+    std::ptrdiff_t n = pptr() - pbase();
+    pbump(-n);
+
+    sink << out.str();
+    return (!sink.fail() && !sink.bad());
+}
+
+//Overridden streambuf functions
+LogUtil::LogUtil_buffer::int_type LogUtil::LogUtil_buffer::overflow(int_type ch)
+{
+    if(sink && ch != traits_type::eof())
+    {
+        assert(std::less_equal<char *>()(pptr(), epptr()));
+        *pptr() = ch;
+        pbump(1);
+        if(timestamp_and_flush())
+            return ch;
+    }
+    return traits_type::eof();
+}
+int LogUtil::LogUtil_buffer::sync()
+{
+    return timestamp_and_flush() ? 0 : -1;
+}
+
+//returns std::string containing current system time.
+//should eventually be updated to use std::put_time
+std::string LogUtil::LogUtil_buffer::timestamp()
+{
+    std::time_t curr_time_raw = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    std::tm *lt = std::localtime(&curr_time_raw);
+
+    std::stringstream time;
+#if USE_STD_PUT_TIME
+    time << "[" << std::put_time(lt, "%T") << "] ";
+#else
+    time << "[" << boost::posix_time::to_simple_string(boost::posix_time::time_duration(lt->tm_hour, lt->tm_min, lt->tm_sec)) << "] ";
+#endif
+    return time.str();
+}
+
+void LogUtil::enableRedirection()
+{
+    static LogUtil lu;
+}
+LogUtil::~LogUtil()
+{
+    std::clog.rdbuf(clogbuf), clogbuf = nullptr;
+    std::cerr.rdbuf(cerrbuf), cerrbuf = nullptr;
+    std::cout.rdbuf(coutbuf), coutbuf = nullptr;
+}

--- a/src/Debug.cpp
+++ b/src/Debug.cpp
@@ -1,4 +1,4 @@
-#include <Debug.hpp>
+#include "Debug.hpp"
 
 
 LogUtil::LogUtil_buffer::LogUtil_buffer(std::ostream &sink_, std::size_t buff_sz )
@@ -10,7 +10,6 @@ LogUtil::LogUtil_buffer::LogUtil_buffer(std::ostream &sink_, std::size_t buff_sz
     setp(base, base + buffer.size()-1); //reserve an extra char for calls to overflow
 }
 
-//Applies timestamps and flushes buffer
 bool LogUtil::LogUtil_buffer::timestamp_and_flush()
 {
     std::stringstream out;
@@ -32,7 +31,6 @@ bool LogUtil::LogUtil_buffer::timestamp_and_flush()
     return (!sink.fail() && !sink.bad());
 }
 
-//Overridden streambuf functions
 LogUtil::LogUtil_buffer::int_type LogUtil::LogUtil_buffer::overflow(int_type ch)
 {
     if(sink && ch != traits_type::eof())
@@ -50,8 +48,6 @@ int LogUtil::LogUtil_buffer::sync()
     return timestamp_and_flush() ? 0 : -1;
 }
 
-//returns std::string containing current system time.
-//should eventually be updated to use std::put_time
 std::string LogUtil::LogUtil_buffer::timestamp()
 {
     std::time_t curr_time_raw = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());

--- a/src/Debug.hpp
+++ b/src/Debug.hpp
@@ -29,14 +29,7 @@ class LogUtil //replaces std::clog, std::cerr, std::cout with file streams
         std::vector<char> buffer;
 
     public:
-        explicit LogUtil_buffer(std::ostream &sink_, std::size_t buff_sz = 256)
-        : sink(sink_)
-        , buffer(buff_sz + 1)
-        {
-            sink.clear();
-            char *base = &buffer.front();
-            setp(base, base + buffer.size()-1); //reserve an extra char for calls to overflow
-        }
+        explicit LogUtil_buffer(std::ostream &sink_, std::size_t buff_sz = 256);
 
     private:
         //Copying disabled
@@ -44,60 +37,17 @@ class LogUtil //replaces std::clog, std::cerr, std::cout with file streams
         LogUtil_buffer &operator=(LogUtil_buffer const &) = delete;
 
         //Applies timestamps and flushes buffer
-        bool timestamp_and_flush()
-        {
-            std::stringstream out;
-            for(char *p = pbase(), *e = pptr(); p != e; ++p)
-            {
-                if(*p == '\n') timestamp_on_next_text = true;
-                else if(timestamp_on_next_text)
-                {
-                    if(!std::isspace(*p)) out << timestamp();
-                    timestamp_on_next_text = false;
-                }
-                out << *p;
-            }
-
-            std::ptrdiff_t n = pptr() - pbase();
-            pbump(-n);
-
-            sink << out.str();
-            return (!sink.fail() && !sink.bad());
-        }
+        bool timestamp_and_flush();
 
         //Overridden streambuf functions
-        int_type overflow(int_type ch) override
-        {
-            if(sink && ch != traits_type::eof())
-            {
-                assert(std::less_equal<char *>()(pptr(), epptr()));
-                *pptr() = ch;
-                pbump(1);
-                if(timestamp_and_flush())
-                    return ch;
-            }
-            return traits_type::eof();
-        }
-        int sync() override
-        {
-            return timestamp_and_flush() ? 0 : -1;
-        }
+        int_type overflow(int_type ch) override;
+
+        int sync() override;
 
         //returns std::string containing current system time.
         //should eventually be updated to use std::put_time
-        static std::string timestamp()
-        {
-            std::time_t curr_time_raw = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-            std::tm *lt = std::localtime(&curr_time_raw);
+        static std::string timestamp();
 
-            std::stringstream time;
-#if USE_STD_PUT_TIME
-            time << "[" << std::put_time(lt, "%T") << "] ";
-#else
-            time << "[" << boost::posix_time::to_simple_string(boost::posix_time::time_duration(lt->tm_hour, lt->tm_min, lt->tm_sec)) << "] ";
-#endif
-            return time.str();
-        }
     };
 
     std::ofstream log {"debug_log.log", std::ios::out|std::ios::trunc}
@@ -114,17 +64,11 @@ class LogUtil //replaces std::clog, std::cerr, std::cout with file streams
     LogUtil(LogUtil &&) = delete;
     LogUtil &operator=(LogUtil const &) = delete;
     LogUtil &operator=(LogUtil &&) = delete;
+
 public:
-    static void enableRedirection()
-    {
-        static LogUtil lu;
-    }
-    ~LogUtil()
-    {
-        std::clog.rdbuf(clogbuf), clogbuf = nullptr;
-        std::cerr.rdbuf(cerrbuf), cerrbuf = nullptr;
-        std::cout.rdbuf(coutbuf), coutbuf = nullptr;
-    }
+
+    static void enableRedirection();
+    ~LogUtil();
 };
 
 #endif

--- a/src/Debug.hpp
+++ b/src/Debug.hpp
@@ -44,8 +44,7 @@ class LogUtil //replaces std::clog, std::cerr, std::cout with file streams
 
         int sync() override;
 
-        //returns std::string containing current system time.
-        //should eventually be updated to use std::put_time
+        //returns std::string containing current system time. should eventually be updated to use std::put_time
         static std::string timestamp();
 
     };

--- a/src/TextureManager.cpp
+++ b/src/TextureManager.cpp
@@ -1,0 +1,37 @@
+#include <TextureManager.hpp>
+
+
+namespace chesspp
+{
+    //Structure used by std::shared_ptr to delete an sf::Texture.
+    //This isn't needed because std::default_delete does the same thing.
+    //Using it for debugging purposes, though.
+    void TextureDeleter::operator()(sf::Texture *texture) noexcept
+    {
+        std::clog << "Deleting texture - unique_ptr has been deleted." << std::endl;
+        delete texture;
+    }
+
+    TextureManager::TextureManager() noexcept
+    {
+    }
+
+    TextureManager &TextureManager::instance() noexcept
+    {
+        static TextureManager inst;
+        return inst;
+    }
+
+  //Method that loads an sf::Texture from file name 'location'.
+  sf::Texture *TextureManager::onLoadResource(std::string const &location) noexcept
+  {
+      sf::Texture *ret = new sf::Texture(); //should change to std::shared_ptr eventually
+      if(!ret->loadFromFile(location))
+      {
+          std::clog << "Failed to load " << location << std::endl;
+          return delete ret, ret = nullptr;
+      }
+      std::clog << "Loaded " << location << " into memory." << std::endl;
+      return ret;
+  }
+}

--- a/src/TextureManager.cpp
+++ b/src/TextureManager.cpp
@@ -1,11 +1,8 @@
-#include <TextureManager.hpp>
+#include "TextureManager.hpp"
 
 
 namespace chesspp
 {
-    //Structure used by std::shared_ptr to delete an sf::Texture.
-    //This isn't needed because std::default_delete does the same thing.
-    //Using it for debugging purposes, though.
     void TextureDeleter::operator()(sf::Texture *texture) noexcept
     {
         std::clog << "Deleting texture - unique_ptr has been deleted." << std::endl;
@@ -22,7 +19,6 @@ namespace chesspp
         return inst;
     }
 
-  //Method that loads an sf::Texture from file name 'location'.
   sf::Texture *TextureManager::onLoadResource(std::string const &location) noexcept
   {
       sf::Texture *ret = new sf::Texture(); //should change to std::shared_ptr eventually

--- a/src/TextureManager.hpp
+++ b/src/TextureManager.hpp
@@ -14,43 +14,23 @@ namespace chesspp
         //Structure used by std::shared_ptr to delete an sf::Texture.
         //This isn't needed because std::default_delete does the same thing.
         //Using it for debugging purposes, though.
-        void operator()(sf::Texture *texture) noexcept
-        {
-            std::clog << "Deleting texture - unique_ptr has been deleted." << std::endl;
-            delete texture;
-        }
+        void operator()(sf::Texture *texture) noexcept;
     };
 
     class TextureManager : public ResourceManager<sf::Texture, std::string, TextureDeleter>
     {
-        TextureManager() noexcept
-        {
-        }
+        TextureManager() noexcept;
 
         //no copying
         TextureManager(TextureManager const &) = delete;
         TextureManager &operator=(TextureManager const &) = delete;
 
     public:
-        static TextureManager &instance() noexcept //singleton class
-        {
-            static TextureManager inst;
-            return inst;
-        }
+        static TextureManager &instance() noexcept; //singleton class
 
     protected:
         //Method that loads an sf::Texture from file name 'location'.
-        virtual sf::Texture *onLoadResource(std::string const &location) noexcept override
-        {
-            sf::Texture *ret = new sf::Texture(); //should change to std::shared_ptr eventually
-            if(!ret->loadFromFile(location))
-            {
-                std::clog << "Failed to load " << location << std::endl;
-                return delete ret, ret = nullptr;
-            }
-            std::clog << "Loaded " << location << " into memory." << std::endl;
-            return ret;
-        }
+        virtual sf::Texture *onLoadResource(std::string const &location) noexcept override;
     };
 }
 

--- a/src/TextureManager.hpp
+++ b/src/TextureManager.hpp
@@ -11,9 +11,7 @@ namespace chesspp
 {
     struct TextureDeleter
     {
-        //Structure used by std::shared_ptr to delete an sf::Texture.
-        //This isn't needed because std::default_delete does the same thing.
-        //Using it for debugging purposes, though.
+        //Structure used by std::shared_ptr to delete an sf::Texture.  This isn't needed because std::default_delete does the same thing.  Using it for debugging purposes, though.
         void operator()(sf::Texture *texture) noexcept;
     };
 

--- a/src/board/Board.cpp
+++ b/src/board/Board.cpp
@@ -6,12 +6,43 @@ namespace chesspp
 {
     namespace board
     {
-        Board::Piece::Piece(Board &b, Position_t const &pos_, Suit const &s_)
-        : board(b)
-        , p(pos_)
-        , s(s_)
+        /***********************************************************************
+         * BOARD
+         **********************************************************************/
+        Board::Board(config::BoardConfig const &conf, Factory_t const &fact)
+        : config(conf)
+        , factory(fact)
         {
-            std::clog << "Creation of " << *this << std::endl;
+            for(auto const &slot : conf.initialLayout())
+            {
+                pieces.emplace(factory.at(slot.second.first)(*this, slot.first, slot.second.second));
+            }
+
+            for(auto const &p : pieces)
+            {
+                p->makeTrajectory();
+            }
+        }
+        bool Board::occupied(Position_t const &pos) const
+        {
+            for(auto const &p : *this)
+            {
+                if(p->pos == pos)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        Board::Pieces_t::const_iterator Board::begin() const
+        {
+            return pieces.begin();
+        }
+
+        Board::Pieces_t::const_iterator Board::end() const
+        {
+            return pieces.end();
         }
 
         void Board::update(Position_t const &pos)
@@ -82,6 +113,208 @@ namespace chesspp
             update(target->second);
             std::clog << " to " << target->second << std::endl;
             return true;
+        }
+
+        Board::Movements const &Board::pieceTrajectories() const
+        {
+            return trajs;
+        }
+
+        Board::Movements const &Board::pieceCapturings() const
+        {
+            return captings;
+        }
+
+        Board::Movements const &Board::pieceCapturables() const
+        {
+            return captables;
+        }
+
+        Board::MovementsRange Board::pieceTrajectory(Piece const &p)
+        {
+            return trajectories.equal_range(p.self());
+        }
+
+        Board::MovementsRange Board::pieceCapturing(Piece const &p)
+        {
+            return capturings.equal_range(p.self());
+        }
+
+        Board::MovementsRange Board::pieceCapturable(Piece const &p)
+        {
+            return capturables.equal_range(p.self());
+        }
+
+        bool Board::valid(Position_t const &pos) const noexcept
+        {
+            return pos.isWithin(Position_t::Origin(), {config.boardWidth(), config.boardHeight()});
+        }
+
+        /***********************************************************************
+         * PIECE
+         **********************************************************************/
+
+        Board::Piece::Piece(Board &b, Position_t const &pos_, Suit const &s_)
+        : board(b)
+        , p(pos_)
+        , s(s_)
+        {
+            std::clog << "Creation of " << *this << std::endl;
+        }
+        //non-virtual, calls calcTrajectory(), which should call
+        //addTrajectory() for each possible tile
+        void Board::Piece::makeTrajectory()
+        {
+            addCapturable(pos);
+            calcTrajectory();
+        }
+
+        //deriving classes should call this from makeTrajectory
+        //to add a calculated trajectory tile
+        void Board::Piece::addTrajectory(Position_t const &tile)
+        {
+            if(board.valid(tile))
+            {
+                board.trajectories.insert(Board::Movements_t::value_type(self(), tile));
+            }
+        }
+        //further deriving classes can call this to remove a
+        //trajectory calculated by their parent class
+        void Board::Piece::removeTrajectory(Position_t const &tile)
+        {
+            auto range = board.trajectories.equal_range(self());
+            for(auto it = range.first; it != range.second; )
+            {
+                if(it->second == tile)
+                {
+                    it = board.trajectories.erase(it);
+                }
+                else ++it;
+            }
+        }
+
+        //deriving classes should call this from makeTrajectory
+        //to add a calculated capturable tile
+        void Board::Piece::addCapturing(Position_t const &tile)
+        {
+            if(board.valid(tile))
+            {
+                board.capturings.insert(Board::Movements_t::value_type(self(), tile));
+            }
+        }
+
+        //further deriving classes can call this
+        //to remove a capturable tile calculated by their parent class
+        void Board::Piece::removeCapturing(Position_t const &tile)
+        {
+            auto range = board.capturings.equal_range(self());
+            for(auto it = range.first; it != range.second; )
+            {
+                if(it->second == tile)
+                {
+                    it = board.capturings.erase(it);
+                }
+                else ++it;
+            }
+        }
+
+        //deriving classes should call this from makeTrajectory
+        //to add a calculated capturable tile
+        void Board::Piece::addCapturable(Position_t const &tile)
+        {
+            if(board.valid(tile))
+            {
+                board.capturables.insert(Board::Movements_t::value_type(self(), tile));
+            }
+        }
+
+        //further deriving classes can call this
+        //to remove a capturable tile calculated by their parent class
+        void Board::Piece::removeCapturable(Position_t const &tile)
+        {
+            auto range = board.capturables.equal_range(self());
+            for(auto it = range.first; it != range.second; )
+            {
+                if(it->second == tile)
+                {
+                    it = board.capturables.erase(it);
+                }
+                else ++it;
+            }
+        }
+
+        //Called with the position of the piece that just moved
+        void Board::Piece::tick(Position_t const &m)
+        {
+        }
+
+        //Sets the piece position as instructed by the board
+        //and recalculates the trajectory
+        void Board::Piece::move(Position_t const &to)
+        {
+            Position_t from = pos;
+            p = to;
+            moveUpdate(from, to);
+            ++movenum;
+        }
+
+        //Called by move(), reacts to being moved
+        void Board::Piece::moveUpdate(Position_t const &from, Position_t const &to)
+        {
+        }
+
+        /***********************************************************************
+         * PIECES_T_INTERATOR_COMPARE
+         **********************************************************************/
+
+        bool Board::Pieces_t_iterator_compare::operator()(Board::Pieces_t::iterator const &a, Board::Pieces_t::iterator const &b) const
+        {
+            return *a < *b;
+        }
+        /***********************************************************************
+         * INTERACTION
+         **********************************************************************/
+
+         Board::Interaction::Interaction ( Board& b )
+         : board(b)
+         {
+         }
+
+        /***********************************************************************
+         * MOVEMENTS
+         **********************************************************************/
+
+        Board::Movements::Movements(Movements_t const &m_)
+        : m(m_)
+        {
+        }
+
+        Board::Movements_t::const_iterator Board::Movements::begin() const
+        {
+            return m.cbegin();
+        }
+
+        Board::Movements_t::const_iterator Board::Movements::end() const
+        {
+            return m.cend();
+        }
+
+        /***********************************************************************
+         * MOVEMENTS RANGE
+         **********************************************************************/
+
+        Board::MovementsRange::MovementsRange(std::pair<Movements_t::iterator, Movements_t::iterator> const &r_)
+        : r(r_)
+        {
+        }
+
+        Board::Movements_t::const_iterator Board::MovementsRange::begin() const
+        {
+            return r.first;
+        }
+        Board::Movements_t::const_iterator Board::MovementsRange::end() const
+        {
+            return r.second;
         }
     }
 }

--- a/src/board/Board.cpp
+++ b/src/board/Board.cpp
@@ -6,9 +6,6 @@ namespace chesspp
 {
     namespace board
     {
-        /***********************************************************************
-         * BOARD
-         **********************************************************************/
         Board::Board(config::BoardConfig const &conf, Factory_t const &fact)
         : config(conf)
         , factory(fact)
@@ -150,10 +147,6 @@ namespace chesspp
             return pos.isWithin(Position_t::Origin(), {config.boardWidth(), config.boardHeight()});
         }
 
-        /***********************************************************************
-         * PIECE
-         **********************************************************************/
-
         Board::Piece::Piece(Board &b, Position_t const &pos_, Suit const &s_)
         : board(b)
         , p(pos_)
@@ -161,16 +154,13 @@ namespace chesspp
         {
             std::clog << "Creation of " << *this << std::endl;
         }
-        //non-virtual, calls calcTrajectory(), which should call
-        //addTrajectory() for each possible tile
+
         void Board::Piece::makeTrajectory()
         {
             addCapturable(pos);
             calcTrajectory();
         }
 
-        //deriving classes should call this from makeTrajectory
-        //to add a calculated trajectory tile
         void Board::Piece::addTrajectory(Position_t const &tile)
         {
             if(board.valid(tile))
@@ -178,8 +168,7 @@ namespace chesspp
                 board.trajectories.insert(Board::Movements_t::value_type(self(), tile));
             }
         }
-        //further deriving classes can call this to remove a
-        //trajectory calculated by their parent class
+
         void Board::Piece::removeTrajectory(Position_t const &tile)
         {
             auto range = board.trajectories.equal_range(self());
@@ -193,8 +182,6 @@ namespace chesspp
             }
         }
 
-        //deriving classes should call this from makeTrajectory
-        //to add a calculated capturable tile
         void Board::Piece::addCapturing(Position_t const &tile)
         {
             if(board.valid(tile))
@@ -203,8 +190,6 @@ namespace chesspp
             }
         }
 
-        //further deriving classes can call this
-        //to remove a capturable tile calculated by their parent class
         void Board::Piece::removeCapturing(Position_t const &tile)
         {
             auto range = board.capturings.equal_range(self());
@@ -218,8 +203,6 @@ namespace chesspp
             }
         }
 
-        //deriving classes should call this from makeTrajectory
-        //to add a calculated capturable tile
         void Board::Piece::addCapturable(Position_t const &tile)
         {
             if(board.valid(tile))
@@ -228,8 +211,6 @@ namespace chesspp
             }
         }
 
-        //further deriving classes can call this
-        //to remove a capturable tile calculated by their parent class
         void Board::Piece::removeCapturable(Position_t const &tile)
         {
             auto range = board.capturables.equal_range(self());
@@ -243,13 +224,10 @@ namespace chesspp
             }
         }
 
-        //Called with the position of the piece that just moved
         void Board::Piece::tick(Position_t const &m)
         {
         }
 
-        //Sets the piece position as instructed by the board
-        //and recalculates the trajectory
         void Board::Piece::move(Position_t const &to)
         {
             Position_t from = pos;
@@ -258,31 +236,20 @@ namespace chesspp
             ++movenum;
         }
 
-        //Called by move(), reacts to being moved
         void Board::Piece::moveUpdate(Position_t const &from, Position_t const &to)
         {
         }
-
-        /***********************************************************************
-         * PIECES_T_INTERATOR_COMPARE
-         **********************************************************************/
 
         bool Board::Pieces_t_iterator_compare::operator()(Board::Pieces_t::iterator const &a, Board::Pieces_t::iterator const &b) const
         {
             return *a < *b;
         }
-        /***********************************************************************
-         * INTERACTION
-         **********************************************************************/
 
-         Board::Interaction::Interaction ( Board& b )
-         : board(b)
-         {
-         }
+        Board::Interaction::Interaction ( Board& b )
+        : board(b)
+        {
+        }
 
-        /***********************************************************************
-         * MOVEMENTS
-         **********************************************************************/
 
         Board::Movements::Movements(Movements_t const &m_)
         : m(m_)
@@ -298,10 +265,6 @@ namespace chesspp
         {
             return m.cend();
         }
-
-        /***********************************************************************
-         * MOVEMENTS RANGE
-         **********************************************************************/
 
         Board::MovementsRange::MovementsRange(std::pair<Movements_t::iterator, Movements_t::iterator> const &r_)
         : r(r_)

--- a/src/board/Board.hpp
+++ b/src/board/Board.hpp
@@ -63,40 +63,32 @@ namespace chesspp
 
             protected:
 
-                //should call addTrajectory() for each calculated trajectory
-                //and addCapture() for each possible capture
+                //should call addTrajectory() for each calculated trajectory and addCapture() for each possible capture
                 virtual void calcTrajectory() = 0;
 
-                //deriving classes should call this from makeTrajectory
-                //to add a calculated trajectory tile
+                //deriving classes should call this from makeTrajectory to add a calculated trajectory tile
                 void addTrajectory(Position_t const &tile);
 
-                //further deriving classes can call this to remove a trajectory
-                //calculated by their parent class
+                //further deriving classes can call this to remove a trajectory calculated by their parent class
                 void removeTrajectory(Position_t const &tile);
 
-                //deriving classes should call this from makeTrajectory
-                //to add a calculated capturable tile
+                //deriving classes should call this from makeTrajectory to add a calculated capturable tile
                 void addCapturing(Position_t const &tile);
 
-                //further deriving classes can call this to remove a capturable
-                //tile calculated by their parent class
+                //further deriving classes can call this to remove a capturable tile calculated by their parent class
                 void removeCapturing(Position_t const &tile);
 
-                //deriving classes should call this from makeTrajectory
-                //to add a calculated capturable tile
+                //deriving classes should call this from makeTrajectory to add a calculated capturable tile
                 void addCapturable(Position_t const &tile);
 
-                //further deriving classes can call this to remove a
-                //capturable tile calculated by their parent class
+                //further deriving classes can call this to remove a capturable tile calculated by their parent class
                 void removeCapturable(Position_t const &tile);
 
             private:
                 //Called with the position of the piece that just moved
                 virtual void tick(Position_t const &m);
 
-                //Sets the piece position as instructed by the board and
-                //recalculates the trajectory
+                //Sets the piece position as instructed by the board and recalculates the trajectory
                 void move(Position_t const &to);
 
                 //Called by move(), reacts to being moved

--- a/src/board/Board.hpp
+++ b/src/board/Board.hpp
@@ -49,11 +49,7 @@ namespace chesspp
                 virtual config::BoardConfig::Textures_t::mapped_type::mapped_type const &texture() const = 0;
 
                 //non-virtual, calls calcTrajectory(), which should call addTrajectory() for each possible tile
-                void makeTrajectory()
-                {
-                    addCapturable(pos);
-                    calcTrajectory();
-                }
+                void makeTrajectory();
 
                 friend bool operator==(std::unique_ptr<Piece> const &up, Piece const *p) noexcept(noexcept(up.get() == p))
                 {
@@ -66,94 +62,45 @@ namespace chesspp
                 }
 
             protected:
+
                 //should call addTrajectory() for each calculated trajectory
                 //and addCapture() for each possible capture
                 virtual void calcTrajectory() = 0;
-                //deriving classes should call this from makeTrajectory to add a calculated trajectory tile
-                void addTrajectory(Position_t const &tile)
-                {
-                    if(board.valid(tile))
-                    {
-                        board.trajectories.insert(Board::Movements_t::value_type(self(), tile));
-                    }
-                }
-                //further deriving classes can call this to remove a trajectory calculated by their parent class
-                void removeTrajectory(Position_t const &tile)
-                {
-                    auto range = board.trajectories.equal_range(self());
-                    for(auto it = range.first; it != range.second; )
-                    {
-                        if(it->second == tile)
-                        {
-                            it = board.trajectories.erase(it);
-                        }
-                        else ++it;
-                    }
-                }
 
-                //deriving classes should call this from makeTrajectory to add a calculated capturable tile
-                void addCapturing(Position_t const &tile)
-                {
-                    if(board.valid(tile))
-                    {
-                        board.capturings.insert(Board::Movements_t::value_type(self(), tile));
-                    }
-                }
-                //further deriving classes can call this to remove a capturable tile calculated by their parent class
-                void removeCapturing(Position_t const &tile)
-                {
-                    auto range = board.capturings.equal_range(self());
-                    for(auto it = range.first; it != range.second; )
-                    {
-                        if(it->second == tile)
-                        {
-                            it = board.capturings.erase(it);
-                        }
-                        else ++it;
-                    }
-                }
+                //deriving classes should call this from makeTrajectory
+                //to add a calculated trajectory tile
+                void addTrajectory(Position_t const &tile);
 
-                //deriving classes should call this from makeTrajectory to add a calculated capturable tile
-                void addCapturable(Position_t const &tile)
-                {
-                    if(board.valid(tile))
-                    {
-                        board.capturables.insert(Board::Movements_t::value_type(self(), tile));
-                    }
-                }
-                //further deriving classes can call this to remove a capturable tile calculated by their parent class
-                void removeCapturable(Position_t const &tile)
-                {
-                    auto range = board.capturables.equal_range(self());
-                    for(auto it = range.first; it != range.second; )
-                    {
-                        if(it->second == tile)
-                        {
-                            it = board.capturables.erase(it);
-                        }
-                        else ++it;
-                    }
-                }
+                //further deriving classes can call this to remove a trajectory
+                //calculated by their parent class
+                void removeTrajectory(Position_t const &tile);
+
+                //deriving classes should call this from makeTrajectory
+                //to add a calculated capturable tile
+                void addCapturing(Position_t const &tile);
+
+                //further deriving classes can call this to remove a capturable
+                //tile calculated by their parent class
+                void removeCapturing(Position_t const &tile);
+
+                //deriving classes should call this from makeTrajectory
+                //to add a calculated capturable tile
+                void addCapturable(Position_t const &tile);
+
+                //further deriving classes can call this to remove a
+                //capturable tile calculated by their parent class
+                void removeCapturable(Position_t const &tile);
 
             private:
                 //Called with the position of the piece that just moved
-                virtual void tick(Position_t const &m)
-                {
-                }
+                virtual void tick(Position_t const &m);
 
-                //Sets the piece position as instructed by the board and recalculates the trajectory
-                void move(Position_t const &to)
-                {
-                    Position_t from = pos;
-                    p = to;
-                    moveUpdate(from, to);
-                    ++movenum;
-                }
+                //Sets the piece position as instructed by the board and
+                //recalculates the trajectory
+                void move(Position_t const &to);
 
                 //Called by move(), reacts to being moved
-                virtual void moveUpdate(Position_t const &from, Position_t const &to)
-                {
-                }
+                virtual void moveUpdate(Position_t const &from, Position_t const &to);
 
             public:
                 friend class ::chesspp::board::Board;
@@ -167,10 +114,7 @@ namespace chesspp
         private:
             struct Pieces_t_iterator_compare
             {
-                bool operator()(Pieces_t::iterator const &a, Pieces_t::iterator const &b) const
-                {
-                    return *a < *b;
-                }
+                bool operator()(Pieces_t::iterator const &a, Pieces_t::iterator const &b) const;
             };
         public:
             using Movements_t = std::multimap<Pieces_t::iterator, Position_t, Pieces_t_iterator_compare>;
@@ -182,10 +126,7 @@ namespace chesspp
             public:
                 Board &board;
 
-                Interaction(Board &b)
-                : board(b)
-                {
-                }
+                Interaction(Board &b);
                 virtual ~Interaction() = 0;
 
                 //
@@ -202,20 +143,7 @@ namespace chesspp
             Interactions_t interactions;
 
         public:
-            Board(config::BoardConfig const &conf, Factory_t const &fact)
-            : config(conf)
-            , factory(fact)
-            {
-                for(auto const &slot : conf.initialLayout())
-                {
-                    pieces.emplace(factory.at(slot.second.first)(*this, slot.first, slot.second.second));
-                }
-
-                for(auto const &p : pieces)
-                {
-                    p->makeTrajectory();
-                }
-            }
+            Board(config::BoardConfig const &conf, Factory_t const &fact);
             ~Board() = default;
 
             template<typename InteractionT>
@@ -230,34 +158,18 @@ namespace chesspp
                 return dynamic_cast<InteractionT &>(*interactions[t]);
             }
 
-            bool occupied(Position_t const &pos) const
-            {
-                for(auto const &p : *this)
-                {
-                    if(p->pos == pos)
-                    {
-                        return true;
-                    }
-                }
-                return false;
-            }
+            bool occupied(Position_t const &pos) const;
 
-            Pieces_t::const_iterator begin() const
-            {
-                return pieces.begin();
-            }
-            Pieces_t::const_iterator end() const
-            {
-                return pieces.end();
-            }
+            Pieces_t::const_iterator begin() const;
+
+            Pieces_t::const_iterator end() const;
 
             class Movements
             {
                 Movements_t const &m;
-                Movements(Movements_t const &m_)
-                : m(m_)
-                {
-                }
+
+                Movements(Movements_t const &m_);
+
                 Movements(Movements const &) = delete;
                 Movements(Movements &&) = delete;
                 Movements &operator=(Movements const &) = delete;
@@ -266,39 +178,24 @@ namespace chesspp
                 friend class ::chesspp::board::Board;
 
             public:
-                Movements_t::const_iterator begin() const
-                {
-                    return m.cbegin();
-                }
-                Movements_t::const_iterator end() const
-                {
-                    return m.cend();
-                }
+
+                Movements_t::const_iterator begin() const;
+                Movements_t::const_iterator end() const;
             };
         private:
             Movements const trajs {trajectories};
             Movements const captings {capturings};
             Movements const captables {capturables};
         public:
-            Movements const &pieceTrajectories() const
-            {
-                return trajs;
-            }
-            Movements const &pieceCapturings() const
-            {
-                return captings;
-            }
-            Movements const &pieceCapturables() const
-            {
-                return captables;
-            }
+            Movements const &pieceTrajectories() const;
+            Movements const   &pieceCapturings() const;
+            Movements const  &pieceCapturables() const;
+
+
             class MovementsRange
             {
                 std::pair<Movements_t::iterator, Movements_t::iterator> r;
-                MovementsRange(std::pair<Movements_t::iterator, Movements_t::iterator> const &r_)
-                : r(r_)
-                {
-                }
+                MovementsRange(std::pair<Movements_t::iterator, Movements_t::iterator> const &r_);
                 MovementsRange(MovementsRange const &) = default;
                 MovementsRange(MovementsRange &&) = default;
                 MovementsRange &operator=(MovementsRange const &) = default;
@@ -306,28 +203,14 @@ namespace chesspp
                 friend class ::chesspp::board::Board;
 
             public:
-                Movements_t::const_iterator begin() const
-                {
-                    return r.first;
-                }
-                Movements_t::const_iterator end() const
-                {
-                    return r.second;
-                }
+                Movements_t::const_iterator begin() const;
+                Movements_t::const_iterator end() const;
                 ~MovementsRange() = default;
             };
-            MovementsRange pieceTrajectory(Piece const &p)
-            {
-                return trajectories.equal_range(p.self());
-            }
-            MovementsRange pieceCapturing(Piece const &p)
-            {
-                return capturings.equal_range(p.self());
-            }
-            MovementsRange pieceCapturable(Piece const &p)
-            {
-                return capturables.equal_range(p.self());
-            }
+
+            MovementsRange pieceTrajectory(Piece const &p);
+            MovementsRange  pieceCapturing(Piece const &p);
+            MovementsRange pieceCapturable(Piece const &p);
 
         private:
             void update(Position_t const &pos);
@@ -338,10 +221,7 @@ namespace chesspp
             bool move(Pieces_t::iterator source, Movements_t::const_iterator target);
 
             //Check if a position is a valid position that exists on the board
-            bool valid(Position_t const &pos) const noexcept
-            {
-                return pos.isWithin(Position_t::Origin(), {config.boardWidth(), config.boardHeight()});
-            }
+            bool valid(Position_t const &pos) const noexcept;
         };
 
         using Suit = Board::Suit;

--- a/src/config/BoardConfig.cpp
+++ b/src/config/BoardConfig.cpp
@@ -1,0 +1,40 @@
+#include <BoardConfig.hpp>
+
+namespace chesspp
+{
+    namespace config
+    {
+        BoardConfig::BoardConfig(GraphicsConfig const &gfx)
+        : Configuration("config/board.json")
+        , board_width  (reader()["chesspp"]["board"]["width"]      )
+        , board_height (reader()["chesspp"]["board"]["height"]     )
+        , cell_width   (reader()["chesspp"]["board"]["cell width"] )
+        , cell_height  (reader()["chesspp"]["board"]["cell height"])
+        {
+            auto pieces = reader()["chesspp"]["board"]["pieces"];
+            auto suits  = reader()["chesspp"]["board"]["suits"];
+            for(BoardSize_t r = 0; r < board_height; ++r)
+            {
+                for(BoardSize_t c = 0; c < board_width; ++c)
+                {
+                    auto piece = pieces[r][c];
+                    auto suit  = suits [r][c];
+                    if(piece.type() != json_null) //it is OK if suit is null
+                    {
+                        layout[{c, r}] = std::make_pair<PieceClass_t, SuitClass_t>(piece, suit);
+                    }
+                }
+            }
+
+            auto const &tex = gfx.spritePaths("board", "pieces");
+            for(auto const &suit : tex)
+            {
+                for(auto const &piece : suit.second.object())
+                {
+                    textures[suit.first][piece.first] = gfx.normalize(Textures_t::mapped_type::mapped_type(piece.second));
+                }
+            }
+        }
+    }
+}
+

--- a/src/config/BoardConfig.cpp
+++ b/src/config/BoardConfig.cpp
@@ -1,4 +1,4 @@
-#include <BoardConfig.hpp>
+#include "BoardConfig.hpp"
 
 namespace chesspp
 {

--- a/src/config/BoardConfig.hpp
+++ b/src/config/BoardConfig.hpp
@@ -31,37 +31,7 @@ namespace chesspp
             Textures_t textures;
 
         public:
-            BoardConfig(GraphicsConfig const &gfx)
-            : Configuration("config/board.json")
-            , board_width  (reader()["chesspp"]["board"]["width"]      )
-            , board_height (reader()["chesspp"]["board"]["height"]     )
-            , cell_width   (reader()["chesspp"]["board"]["cell width"] )
-            , cell_height  (reader()["chesspp"]["board"]["cell height"])
-            {
-                auto pieces = reader()["chesspp"]["board"]["pieces"];
-                auto suits  = reader()["chesspp"]["board"]["suits"];
-                for(BoardSize_t r = 0; r < board_height; ++r)
-                {
-                    for(BoardSize_t c = 0; c < board_width; ++c)
-                    {
-                        auto piece = pieces[r][c];
-                        auto suit  = suits [r][c];
-                        if(piece.type() != json_null) //it is OK if suit is null
-                        {
-                            layout[{c, r}] = std::make_pair<PieceClass_t, SuitClass_t>(piece, suit);
-                        }
-                    }
-                }
-
-                auto const &tex = gfx.spritePaths("board", "pieces");
-                for(auto const &suit : tex)
-                {
-                    for(auto const &piece : suit.second.object())
-                    {
-                        textures[suit.first][piece.first] = gfx.normalize(Textures_t::mapped_type::mapped_type(piece.second));
-                    }
-                }
-            }
+            BoardConfig(GraphicsConfig const &gfx);
             virtual ~BoardConfig() = default;
 
             BoardSize_t       boardWidth   () const noexcept { return board_width;  }

--- a/src/config/Configuration.cpp
+++ b/src/config/Configuration.cpp
@@ -20,7 +20,7 @@ namespace chesspp
         //<.app>/Contents/Resources/res/img... should be where resources are stored.
         std::string Configuration::executablePath()
         {
-            
+
             char buf[1024];
             std::uint32_t size = sizeof(buf);
             memset(buf, 0, size);
@@ -53,6 +53,30 @@ namespace chesspp
             std::clog << "Executable path = \"" << ret << '"' << std::endl;
 
             return ret;
+        }
+        std::string Configuration::validateConfigFile(std::string const &configFile)
+        {
+            static std::string exe_path = executablePath();
+
+            if(boost::filesystem::extension(configFile) != ".json")
+            {
+                throw Exception("Configuration cannot read non-json config files.");
+            }
+
+            if(boost::filesystem::exists(configFile))
+            {
+                res_path = "";
+            }
+            else
+            {
+                res_path = exe_path;
+            }
+            return res_path + configFile;
+        }
+
+        Configuration::Configuration(std::string const &configFile) noexcept(false)
+        : reader(std::ifstream(validateConfigFile(configFile)))
+        {
         }
     }
 }

--- a/src/config/Configuration.hpp
+++ b/src/config/Configuration.hpp
@@ -23,31 +23,10 @@ namespace chesspp
             util::JsonReader reader;
 
         private:
-            std::string validateConfigFile(std::string const &configFile)
-            {
-                static std::string exe_path = executablePath();
-
-                if(boost::filesystem::extension(configFile) != ".json")
-                {
-                    throw Exception("Configuration cannot read non-json config files.");
-                }
-
-                if(boost::filesystem::exists(configFile))
-                {
-                    res_path = "";
-                }
-                else
-                {
-                    res_path = exe_path;
-                }
-                return res_path + configFile;
-            }
+            std::string validateConfigFile(std::string const &configFile);
 
         public:
-            Configuration(std::string const &configFile) noexcept(false)
-            : reader(std::ifstream(validateConfigFile(configFile)))
-            {
-            }
+            Configuration(std::string const &configFile) noexcept(false);
             virtual ~Configuration() = default;
         };
     }

--- a/src/config/GraphicsConfig.hpp
+++ b/src/config/GraphicsConfig.hpp
@@ -14,12 +14,14 @@ namespace chesspp
             : Configuration("config/graphics.json")
             {
             }
+
             virtual ~GraphicsConfig() = default;
 
             std::string normalize(std::string const &path) const
             {
                 return res_path + path;
             }
+
             template<typename... Args>
             std::string spritePath(Args const &... path) const
             {
@@ -30,6 +32,7 @@ namespace chesspp
                 }
                 return normalize(val);
             }
+
             //Must normalize return value
             template<typename... Args>
             auto spritePaths(Args const &... path) const -> std::map<std::string, util::JsonReader::NestedValue>

--- a/src/util/JsonReader.cpp
+++ b/src/util/JsonReader.cpp
@@ -1,0 +1,246 @@
+#include <JsonReader.hpp>
+
+namespace chesspp
+{
+    namespace util
+    {
+        /**
+         * Constructs this JsonReader from the given stream.
+         * The stream is read to EOF.
+         * \param s The stream containing the JSON.
+         */
+        JsonReader::JsonReader(std::istream &s)
+        {
+            if(!s)
+            {
+                throw Exception("stream given to JsonReader in bad state");
+            }
+            std::string str ((std::istreambuf_iterator<char>(s)), std::istreambuf_iterator<char>());
+            json_settings options {0, 0, nullptr, nullptr, nullptr};
+            char error[json_error_max];
+            json = json_parse_ex(&options, str.c_str(), str.length(), error);
+            if(json == nullptr)
+            {
+                //no manual cleanup needed
+                throw Exception(std::string("Error loading JSON: ") + error);
+            }
+        }
+        /**
+         * Constructs this JsonReader from the given temporary stream.
+         * The stream is read to EOF.
+         * \param s The temporary stream containing the JSON.
+         */
+        JsonReader::JsonReader(std::istream &&s)
+        : JsonReader(s)
+        {
+        }
+        /**
+         * Move-constructs this JsonReader from another.
+         * \param from the JsonReader to move.
+         */
+        JsonReader::JsonReader(JsonReader &&from)
+        : json(from.json)
+        {
+            from.json = nullptr;
+        }
+        /**
+         * Move-assigns this JsonReader from a given stream rvalue.
+         * The stream is read to EOF. Returns *this
+         * \param s The stream containing the JSON.
+         */
+        JsonReader &JsonReader::operator=(std::istream &&s)
+        {
+            *this = JsonReader(s); //move assign
+            return *this;
+        }
+        /**
+         * Move-assigns this JsonReader from another.
+         * \param from the JsonReader to move.
+         */
+        JsonReader &JsonReader::operator=(JsonReader &&from)
+        {
+            std::swap(json, from.json);
+            return *this;
+        }
+        /**
+         * Destructs this JsonReader freeing any allocated memory.
+         */
+        JsonReader::~JsonReader()
+        {
+            json_value_free(json), json = nullptr;
+        }
+
+        /**
+         * Represents a value in the JSON.
+         * Instances of this class should not exceed the
+         * lifetime of the JsonReader that they came from.
+         * Attempting to access a NestedValue for which the
+         * associated JsonReader has been destructed results
+         * in undefined behavior. Two or more instances of
+         * this class may represent the same nested value in
+         * the JSON.
+         */
+        /**
+         * Constructs this NestedValue from a json_value.
+         * Note that this constructor is private and for
+         * implementation use only.
+         * \param value_ The json_value this instance shall represent.
+         */
+        JsonReader::NestedValue::NestedValue(json_value const &value_) noexcept
+        : value(value_)
+        {
+        }
+
+        /**
+         * Returns the type of this value.
+         * Note that the return value is a type
+         * from the json-parse library. It may
+         * be compared to these constants:
+         * json_null
+         * json_boolean
+         * json_integer
+         * json_double
+         * json_string
+         * json_array
+         * json_object
+         * \return The type of value represented.
+         */
+        json_type JsonReader::NestedValue::type() const noexcept //may wish to add an abstraction layer between json-parser
+        {
+            return value.type;
+        }
+        /**
+         * Returns the parent NestedValue or throws
+         * ::chesspp::Exception.
+         * \return the parent NestedValue.
+         * \throws ::chesspp::Exception
+         */
+        JsonReader::NestedValue JsonReader::NestedValue::parent() const
+        {
+            if(value.parent)
+            {
+                return *value.parent;
+            }
+            throw Exception("No parent json value");
+        }
+
+        /**
+         * Returns a NestedValue within this one by name.
+         * Only works if type() == json_object
+         * \param name the name of the nested JSON value.
+         * \return the NestedValue by name.
+         */
+        JsonReader::NestedValue JsonReader::NestedValue::operator[](std::string const &name) const noexcept(noexcept(name.c_str()))
+        {
+            return value[name.c_str()];
+        }
+        /**
+         * Returns a NestedValue within this one by name.
+         * Only works if type() == json_object
+         * \param name the name of the nested JSON value.
+         * \return the NestedValue by name.
+         */
+        JsonReader::NestedValue JsonReader::NestedValue::operator[](char const *name) const //without this, ambiguity occurs
+        {
+            return value[name];
+        }
+        /**
+         * Returns the length of array values.
+         * \return The length of the array, or 0 if not an array.
+         */
+        std::size_t JsonReader::NestedValue::length() const noexcept
+        {
+            if(value.type == json_array)
+            {
+                return value.u.array.length;
+            }
+            return 0;
+        }
+        /**
+         * Returns the nested value at the given array index.
+         * Only works if type() == json_array
+         * \param index The index within the array.
+         * \return the nested value at the given index.
+         */
+        JsonReader::NestedValue JsonReader::NestedValue::operator[](std::size_t index) const noexcept
+        {
+            return value[static_cast<int>(index)];
+        }
+        /**
+         * Provides a std::map-based view of
+         * an object value, mapping object keys
+         * to object values. Only works if
+         * type() == json_object
+         * \return a std::map of object keys ot obejct values
+         */
+        std::map<std::string, JsonReader::NestedValue> JsonReader::NestedValue::object() const
+        {
+            std::map<std::string, NestedValue> obj;
+            if(value.type == json_object)
+            {
+                for(std::size_t i = 0; i < value.u.object.length; ++i)
+                {
+                    obj.insert(std::make_pair<std::string const, NestedValue>(value.u.object.values[i].name, *value.u.object.values[i].value));
+                }
+            }
+            return obj;
+        }
+        /**
+         * Returns the string representation of this string value.
+         * Only works if type() == json_string
+         * \return The string
+         */
+        JsonReader::NestedValue::operator std::string() const noexcept(noexcept(std::string("")))
+        {
+            return static_cast<char const *>(value);
+        }
+        /**
+         * Returns the boolean state of this bool value.
+         * Only works if type() == json_bool.
+         * \return The boolean.
+         */
+        JsonReader::NestedValue::operator bool() const noexcept
+        {
+            return value;
+        }
+        /**
+         * Returns the floating-point value of this double.
+         * Only works if type() == json_double
+         * \return The double.
+         */
+        JsonReader::NestedValue::operator double() const noexcept
+        {
+            return value;
+        }
+
+        /**
+         * Only for extreme use cases: returns the
+         * underlying json_value being wrapped.
+         * \return the underlying json_value
+         */
+        json_value const &JsonReader::NestedValue::implementation() noexcept
+        {
+            return value;
+        }
+
+        /**
+         * Returns a NestedValue view into
+         * this JSON.
+         * \return a NestedValue view into this JSON.
+         */
+        JsonReader::NestedValue JsonReader::access() const noexcept
+        {
+            return *json;
+        }
+        /**
+         * Returns a NestedValue view into
+         * this JSON.
+         * \return a NestedValue view into this JSON.
+         */
+        JsonReader::NestedValue JsonReader::operator()() const noexcept
+        {
+            return access();
+        }
+    }
+}
+

--- a/src/util/JsonReader.cpp
+++ b/src/util/JsonReader.cpp
@@ -1,14 +1,9 @@
-#include <JsonReader.hpp>
+#include "JsonReader.hpp"
 
 namespace chesspp
 {
     namespace util
     {
-        /**
-         * Constructs this JsonReader from the given stream.
-         * The stream is read to EOF.
-         * \param s The stream containing the JSON.
-         */
         JsonReader::JsonReader(std::istream &s)
         {
             if(!s)
@@ -25,96 +20,39 @@ namespace chesspp
                 throw Exception(std::string("Error loading JSON: ") + error);
             }
         }
-        /**
-         * Constructs this JsonReader from the given temporary stream.
-         * The stream is read to EOF.
-         * \param s The temporary stream containing the JSON.
-         */
         JsonReader::JsonReader(std::istream &&s)
         : JsonReader(s)
         {
         }
-        /**
-         * Move-constructs this JsonReader from another.
-         * \param from the JsonReader to move.
-         */
         JsonReader::JsonReader(JsonReader &&from)
         : json(from.json)
         {
             from.json = nullptr;
         }
-        /**
-         * Move-assigns this JsonReader from a given stream rvalue.
-         * The stream is read to EOF. Returns *this
-         * \param s The stream containing the JSON.
-         */
         JsonReader &JsonReader::operator=(std::istream &&s)
         {
             *this = JsonReader(s); //move assign
             return *this;
         }
-        /**
-         * Move-assigns this JsonReader from another.
-         * \param from the JsonReader to move.
-         */
         JsonReader &JsonReader::operator=(JsonReader &&from)
         {
             std::swap(json, from.json);
             return *this;
         }
-        /**
-         * Destructs this JsonReader freeing any allocated memory.
-         */
         JsonReader::~JsonReader()
         {
             json_value_free(json), json = nullptr;
         }
 
-        /**
-         * Represents a value in the JSON.
-         * Instances of this class should not exceed the
-         * lifetime of the JsonReader that they came from.
-         * Attempting to access a NestedValue for which the
-         * associated JsonReader has been destructed results
-         * in undefined behavior. Two or more instances of
-         * this class may represent the same nested value in
-         * the JSON.
-         */
-        /**
-         * Constructs this NestedValue from a json_value.
-         * Note that this constructor is private and for
-         * implementation use only.
-         * \param value_ The json_value this instance shall represent.
-         */
         JsonReader::NestedValue::NestedValue(json_value const &value_) noexcept
         : value(value_)
         {
         }
 
-        /**
-         * Returns the type of this value.
-         * Note that the return value is a type
-         * from the json-parse library. It may
-         * be compared to these constants:
-         * json_null
-         * json_boolean
-         * json_integer
-         * json_double
-         * json_string
-         * json_array
-         * json_object
-         * \return The type of value represented.
-         */
-        json_type JsonReader::NestedValue::type() const noexcept //may wish to add an abstraction layer between json-parser
+        json_type JsonReader::NestedValue::type() const noexcept
         {
             return value.type;
         }
-        /**
-         * Returns the parent NestedValue or throws
-         * ::chesspp::Exception.
-         * \return the parent NestedValue.
-         * \throws ::chesspp::Exception
-         */
         JsonReader::NestedValue JsonReader::NestedValue::parent() const
         {
             if(value.parent)
@@ -124,30 +62,14 @@ namespace chesspp
             throw Exception("No parent json value");
         }
 
-        /**
-         * Returns a NestedValue within this one by name.
-         * Only works if type() == json_object
-         * \param name the name of the nested JSON value.
-         * \return the NestedValue by name.
-         */
         JsonReader::NestedValue JsonReader::NestedValue::operator[](std::string const &name) const noexcept(noexcept(name.c_str()))
         {
             return value[name.c_str()];
         }
-        /**
-         * Returns a NestedValue within this one by name.
-         * Only works if type() == json_object
-         * \param name the name of the nested JSON value.
-         * \return the NestedValue by name.
-         */
-        JsonReader::NestedValue JsonReader::NestedValue::operator[](char const *name) const //without this, ambiguity occurs
+        JsonReader::NestedValue JsonReader::NestedValue::operator[](char const *name) const
         {
             return value[name];
         }
-        /**
-         * Returns the length of array values.
-         * \return The length of the array, or 0 if not an array.
-         */
         std::size_t JsonReader::NestedValue::length() const noexcept
         {
             if(value.type == json_array)
@@ -156,23 +78,10 @@ namespace chesspp
             }
             return 0;
         }
-        /**
-         * Returns the nested value at the given array index.
-         * Only works if type() == json_array
-         * \param index The index within the array.
-         * \return the nested value at the given index.
-         */
         JsonReader::NestedValue JsonReader::NestedValue::operator[](std::size_t index) const noexcept
         {
             return value[static_cast<int>(index)];
         }
-        /**
-         * Provides a std::map-based view of
-         * an object value, mapping object keys
-         * to object values. Only works if
-         * type() == json_object
-         * \return a std::map of object keys ot obejct values
-         */
         std::map<std::string, JsonReader::NestedValue> JsonReader::NestedValue::object() const
         {
             std::map<std::string, NestedValue> obj;
@@ -185,58 +94,28 @@ namespace chesspp
             }
             return obj;
         }
-        /**
-         * Returns the string representation of this string value.
-         * Only works if type() == json_string
-         * \return The string
-         */
         JsonReader::NestedValue::operator std::string() const noexcept(noexcept(std::string("")))
         {
             return static_cast<char const *>(value);
         }
-        /**
-         * Returns the boolean state of this bool value.
-         * Only works if type() == json_bool.
-         * \return The boolean.
-         */
         JsonReader::NestedValue::operator bool() const noexcept
         {
             return value;
         }
-        /**
-         * Returns the floating-point value of this double.
-         * Only works if type() == json_double
-         * \return The double.
-         */
         JsonReader::NestedValue::operator double() const noexcept
         {
             return value;
         }
 
-        /**
-         * Only for extreme use cases: returns the
-         * underlying json_value being wrapped.
-         * \return the underlying json_value
-         */
         json_value const &JsonReader::NestedValue::implementation() noexcept
         {
             return value;
         }
 
-        /**
-         * Returns a NestedValue view into
-         * this JSON.
-         * \return a NestedValue view into this JSON.
-         */
         JsonReader::NestedValue JsonReader::access() const noexcept
         {
             return *json;
         }
-        /**
-         * Returns a NestedValue view into
-         * this JSON.
-         * \return a NestedValue view into this JSON.
-         */
         JsonReader::NestedValue JsonReader::operator()() const noexcept
         {
             return access();

--- a/src/util/JsonReader.hpp
+++ b/src/util/JsonReader.hpp
@@ -36,66 +36,37 @@ namespace chesspp
              * The stream is read to EOF.
              * \param s The stream containing the JSON.
              */
-            JsonReader(std::istream &s)
-            {
-                if(!s)
-                {
-                    throw Exception("stream given to JsonReader in bad state");
-                }
-                std::string str ((std::istreambuf_iterator<char>(s)), std::istreambuf_iterator<char>());
-                json_settings options {0, 0, nullptr, nullptr, nullptr};
-                char error[json_error_max];
-                json = json_parse_ex(&options, str.c_str(), str.length(), error);
-                if(json == nullptr)
-                {
-                    //no manual cleanup needed
-                    throw Exception(std::string("Error loading JSON: ") + error);
-                }
-            }
+            JsonReader(std::istream &s);
+
             /**
              * Constructs this JsonReader from the given temporary stream.
              * The stream is read to EOF.
              * \param s The temporary stream containing the JSON.
              */
-            JsonReader(std::istream &&s)
-            : JsonReader(s)
-            {
-            }
+            JsonReader(std::istream &&s);
+
             /**
              * Move-constructs this JsonReader from another.
              * \param from the JsonReader to move.
              */
-            JsonReader(JsonReader &&from)
-            : json(from.json)
-            {
-                from.json = nullptr;
-            }
+            JsonReader(JsonReader &&from);
+
             /**
              * Move-assigns this JsonReader from a given stream rvalue.
              * The stream is read to EOF. Returns *this
              * \param s The stream containing the JSON.
              */
-            JsonReader &operator=(std::istream &&s)
-            {
-                *this = JsonReader(s); //move assign
-                return *this;
-            }
+            JsonReader &operator=(std::istream &&s);
+
             /**
              * Move-assigns this JsonReader from another.
              * \param from the JsonReader to move.
              */
-            JsonReader &operator=(JsonReader &&from)
-            {
-                std::swap(json, from.json);
-                return *this;
-            }
+            JsonReader &operator=(JsonReader &&from);
             /**
              * Destructs this JsonReader freeing any allocated memory.
              */
-            ~JsonReader()
-            {
-                json_value_free(json), json = nullptr;
-            }
+            ~JsonReader();
 
             /**
              * Represents a value in the JSON.
@@ -120,10 +91,7 @@ namespace chesspp
                  * implementation use only.
                  * \param value_ The json_value this instance shall represent.
                  */
-                NestedValue(json_value const &value_) noexcept
-                : value(value_)
-                {
-                }
+                NestedValue(json_value const &value_) noexcept;
                 NestedValue &operator=(NestedValue const &) noexcept = delete;
             public:
                 NestedValue(NestedValue const &) = default;
@@ -145,24 +113,14 @@ namespace chesspp
                  * json_object
                  * \return The type of value represented.
                  */
-                json_type type() const noexcept //may wish to add an abstraction layer between json-parser
-                {
-                    return value.type;
-                }
+                json_type type() const noexcept; //may wish to add an abstraction layer between json-parser
                 /**
                  * Returns the parent NestedValue or throws
                  * ::chesspp::Exception.
                  * \return the parent NestedValue.
                  * \throws ::chesspp::Exception
                  */
-                NestedValue parent() const
-                {
-                    if(value.parent)
-                    {
-                        return *value.parent;
-                    }
-                    throw Exception("No parent json value");
-                }
+                NestedValue parent() const;
 
                 /**
                  * Returns a NestedValue within this one by name.
@@ -170,42 +128,30 @@ namespace chesspp
                  * \param name the name of the nested JSON value.
                  * \return the NestedValue by name.
                  */
-                NestedValue operator[](std::string const &name) const noexcept(noexcept(name.c_str()))
-                {
-                    return value[name.c_str()];
-                }
+                NestedValue operator[](std::string const &name) const noexcept(noexcept(name.c_str()));
+
                 /**
                  * Returns a NestedValue within this one by name.
                  * Only works if type() == json_object
                  * \param name the name of the nested JSON value.
                  * \return the NestedValue by name.
                  */
-                NestedValue operator[](char const *name) const //without this, ambiguity occurs
-                {
-                    return value[name];
-                }
+                NestedValue operator[](char const *name) const; //without this, ambiguity occurs
+
                 /**
                  * Returns the length of array values.
                  * \return The length of the array, or 0 if not an array.
                  */
-                std::size_t length() const noexcept
-                {
-                    if(value.type == json_array)
-                    {
-                        return value.u.array.length;
-                    }
-                    return 0;
-                }
+                std::size_t length() const noexcept;
+
                 /**
                  * Returns the nested value at the given array index.
                  * Only works if type() == json_array
                  * \param index The index within the array.
                  * \return the nested value at the given index.
                  */
-                NestedValue operator[](std::size_t index) const noexcept
-                {
-                    return value[static_cast<int>(index)];
-                }
+                NestedValue operator[](std::size_t index) const noexcept;
+
                 /**
                  * Provides a std::map-based view of
                  * an object value, mapping object keys
@@ -213,27 +159,15 @@ namespace chesspp
                  * type() == json_object
                  * \return a std::map of object keys ot obejct values
                  */
-                std::map<std::string, NestedValue> object() const
-                {
-                    std::map<std::string, NestedValue> obj;
-                    if(value.type == json_object)
-                    {
-                        for(std::size_t i = 0; i < value.u.object.length; ++i)
-                        {
-                            obj.insert(std::make_pair<std::string const, NestedValue>(value.u.object.values[i].name, *value.u.object.values[i].value));
-                        }
-                    }
-                    return obj;
-                }
+                std::map<std::string, NestedValue> object() const;
+
                 /**
                  * Returns the string representation of this string value.
                  * Only works if type() == json_string
                  * \return The string
                  */
-                operator std::string() const noexcept(noexcept(std::string("")))
-                {
-                    return static_cast<char const *>(value);
-                }
+                operator std::string() const noexcept(noexcept(std::string("")));
+
                 //I tried an approach with templates, but the compiler was never able to deduce the corect template argument
                 operator std::  int8_t() const noexcept { return static_cast<std::  int8_t>(static_cast<json_int_t>(value)); }
                 operator std:: uint8_t() const noexcept { return static_cast<std:: uint8_t>(static_cast<json_int_t>(value)); }
@@ -248,29 +182,20 @@ namespace chesspp
                  * Only works if type() == json_bool.
                  * \return The boolean.
                  */
-                operator bool() const noexcept
-                {
-                    return value;
-                }
+                operator bool() const noexcept;
                 /**
                  * Returns the floating-point value of this double.
                  * Only works if type() == json_double
                  * \return The double.
                  */
-                operator double() const noexcept
-                {
-                    return value;
-                }
+                operator double() const noexcept;
 
                 /**
                  * Only for extreme use cases: returns the
                  * underlying json_value being wrapped.
                  * \return the underlying json_value
                  */
-                json_value const &implementation() noexcept
-                {
-                    return value;
-                }
+                json_value const &implementation() noexcept;
             };
 
             /**
@@ -278,19 +203,13 @@ namespace chesspp
              * this JSON.
              * \return a NestedValue view into this JSON.
              */
-            NestedValue access() const noexcept
-            {
-                return *json;
-            }
+            NestedValue access() const noexcept;
             /**
              * Returns a NestedValue view into
              * this JSON.
              * \return a NestedValue view into this JSON.
              */
-            NestedValue operator()() const noexcept
-            {
-                return access();
-            }
+            NestedValue operator()() const noexcept;
             /**
              * Navigates through obejct values and array values
              * and returns a NestedValue at the destination.


### PR DESCRIPTION
fixes #57

I moved much code from the headers into the source.  I find it easier to see what a class is doing this way.  Another benefit is that one can alter code in Board.cpp without having to recompile all of the pieces.

Enough of utils/Position.hpp is templated I didn't feel the need to extract the two methods up top.