### PR TITLE
Change logging to append

### DIFF
--- a/src/Debug.hpp
+++ b/src/Debug.hpp
@@ -100,9 +100,9 @@ class LogUtil //replaces std::clog, std::cerr, std::cout with file streams
         }
     };
 
-    std::ofstream log {"debug_log.log", std::ios::out|std::ios::trunc}
-                , err {"debug_err.log", std::ios::out|std::ios::trunc}
-                , out {"debug_out.log", std::ios::out|std::ios::trunc};
+    std::ofstream log {"debug_log.log", std::ios::out|std::ios::app}
+                , err {"debug_err.log", std::ios::out|std::ios::app}
+                , out {"debug_out.log", std::ios::out|std::ios::app};
     LogUtil_buffer logbuf {log}
                  , errbuf {err}
                  , outbuf {out};


### PR DESCRIPTION
I changed the logging to append, rather than truncate. I believe people will be expecting log information to not be wiped between runs.

This is a reopen of #62 & #61 
