### PR TITLE
Force flush() of logging output stream

### DIFF
--- a/src/Debug.hpp
+++ b/src/Debug.hpp
@@ -68,6 +68,7 @@ class LogUtil //replaces std::clog, std::cerr, std::cout with file streams
             pbump(-n);
 
             sink << out.str();
+            sink.flush();
             return (!sink.fail() && !sink.bad());
         }
 


### PR DESCRIPTION
Logging was not actually performing any flush, so the logs would not get updated until termination.
I tend to `tail -f debug_log.log` so the lack of flush()ing made that useless.
