### PR TITLE
Fix UD behavior. State is destructed after changeState

### DIFF
--- a/src/app/StartMenuState.cpp
+++ b/src/app/StartMenuState.cpp
@@ -48,7 +48,7 @@ namespace chesspp
             if(start_text.getGlobalBounds().contains(x,y))
             {
                 std::clog << "State changing to ChessPlusPlus" << std::endl;
-                app.changeState<ChessPlusPlusState>(std::ref(app), std::ref(display));
+                return app.changeState<ChessPlusPlusState>(std::ref(app), std::ref(display));
             }
 
             //If clicked on Exit button


### PR DESCRIPTION
It was brought to my attention that StartMenuState is destructed after the call to app.changeState(), which could lead to undefined behavior when this method finishes.
